### PR TITLE
chore(DCP-1614): :lock: upgrade jinja to 3.1.6 as per snyk req

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,4 +2,4 @@ Sphinx==7.4.7
 sphinx-rtd-theme==2.1.0rc2
 readthedocs-sphinx-ext==2.2.5
 docutils==0.20.1
-Jinja2==3.1.4
+Jinja2==3.1.6


### PR DESCRIPTION
encompasses [3 Medium snyk issues](https://app.snyk.io/org/stream-QoKwzbbYgxQrFD2XJ6mkew/project/812419aa-d621-4a09-bc0f-0e6150e49228) around template injection and improper neutralisation
 
